### PR TITLE
Merge upstream changes into split packet fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Bugfixed version of rehlds contains an additional cvars:
 <li>sv_rehlds_stringcmdrate_burst_punish // Time in minutes for which the player will be banned (0 - Permanent, use a negative number for a kick). Default: 5
 <li>sv_rehlds_userinfo_transmitted_fields // Userinfo fields only with these keys will be transmitted to clients via network. If not set then all fields will be transmitted (except prefixed with underscore). Each key must be prefixed by backslash, for example "\name\model\*sid\*hltv\bottomcolor\topcolor". See [wiki](https://github.com/dreamstalker/rehlds/wiki/Userinfo-keys) to collect sufficient set of keys for your server. Default: ""
 <li>sv_rehlds_attachedentities_playeranimationspeed_fix // Fixes bug with gait animation speed increase when player has some attached entities (aiments). Can cause animation lags when cl_updaterate is low. Default: 0
+<li>sv_rehlds_maxclients_from_single_ip // Limit number of connections from the single ip address. Default: 5
 </ul>
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Bugfixed version of rehlds contains an additional cvars:
 <li>sv_rehlds_stringcmdrate_avg_punish // Time in minutes for which the player will be banned (0 - Permanent, use a negative number for a kick). Default: 5
 <li>sv_rehlds_stringcmdrate_max_burst // Max burst level of 'string' cmds for ban. Default: 400
 <li>sv_rehlds_stringcmdrate_burst_punish // Time in minutes for which the player will be banned (0 - Permanent, use a negative number for a kick). Default: 5
-<li>sv_rehlds_userinfo_transmitted_fields // Userinfo fields only with these keys will be transmitted to clients via network. If not set then all fields will be transmitted (except prefixed with underscore). Each key must be prefixed by backslash, for example "\name\model\*sid\*hltv\bottomcolor\topcolor". Default: ""
+<li>sv_rehlds_userinfo_transmitted_fields // Userinfo fields only with these keys will be transmitted to clients via network. If not set then all fields will be transmitted (except prefixed with underscore). Each key must be prefixed by backslash, for example "\name\model\*sid\*hltv\bottomcolor\topcolor". See [wiki](https://github.com/dreamstalker/rehlds/wiki/Userinfo-keys) to collect sufficient set of keys for your server. Default: ""
 <li>sv_rehlds_attachedentities_playeranimationspeed_fix // Fixes bug with gait animation speed increase when player has some attached entities (aiments). Can cause animation lags when cl_updaterate is low. Default: 0
 </ul>
 

--- a/rehlds/HLTV/Console/msvc/Console.vcxproj
+++ b/rehlds/HLTV/Console/msvc/Console.vcxproj
@@ -159,7 +159,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>HLTV;WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HLTV;HLTV_FIXES;WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)\..\src;$(ProjectDir)\..\..\;$(ProjectDir)\..\..\..\;$(ProjectDir)\..\..\..\common;$(ProjectDir)\..\..\..\engine;$(ProjectDir)\..\..\..\public;$(ProjectDir)\..\..\..\public\rehlds;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -190,7 +190,7 @@
       <Optimization>Disabled</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HLTV;WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HLTV;HLTV_FIXES;WIN32;NDEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)\..\src;$(ProjectDir)\..\..\;$(ProjectDir)\..\..\..\;$(ProjectDir)\..\..\..\common;$(ProjectDir)\..\..\..\engine;$(ProjectDir)\..\..\..\public;$(ProjectDir)\..\..\..\public\rehlds;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/rehlds/HLTV/Core/build.gradle
+++ b/rehlds/HLTV/Core/build.gradle
@@ -20,7 +20,7 @@ void setupToolchain(NativeBinarySpec b) {
 	cfg.projectInclude(project, '/..', '/../..', '/src', '/../../common', '/../../engine', '/../../public', '/../../public/rehlds', '/../../pm_shared');
 	cfg.projectInclude(dep_bzip2, '/include')
 
-	cfg.singleDefines 'USE_BREAKPAD_HANDLER', 'HLTV', 'CORE_MODULE'
+	cfg.singleDefines 'USE_BREAKPAD_HANDLER', 'HLTV', 'HLTV_FIXES', 'CORE_MODULE'
 
 	if (cfg instanceof MsvcToolchainConfig) {
 		cfg.compilerOptions.pchConfig = new MsvcToolchainConfig.PrecompiledHeadersConfig(

--- a/rehlds/HLTV/Core/msvc/Core.vcxproj
+++ b/rehlds/HLTV/Core/msvc/Core.vcxproj
@@ -77,7 +77,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>HLTV;WIN32;_DEBUG;_WINDOWS;_USRDLL;CORE_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HLTV;HLTV_FIXES;WIN32;_DEBUG;_WINDOWS;_USRDLL;CORE_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>
       </SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir)\..\src;$(ProjectDir)\..\..\;$(ProjectDir)\..\..\..\;$(ProjectDir)\..\..\..\common;$(ProjectDir)\..\..\..\engine;$(ProjectDir)\..\..\..\public;$(ProjectDir)\..\..\..\public\rehlds;$(ProjectDir)\..\..\..\pm_shared;$(ProjectDir)\..\..\..\..\dep\bzip2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -112,7 +112,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HLTV;WIN32;NDEBUG;_WINDOWS;_USRDLL;CORE_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HLTV;HLTV_FIXES;WIN32;NDEBUG;_WINDOWS;_USRDLL;CORE_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>
       </SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir)\..\src;$(ProjectDir)\..\..\;$(ProjectDir)\..\..\..\;$(ProjectDir)\..\..\..\common;$(ProjectDir)\..\..\..\engine;$(ProjectDir)\..\..\..\public;$(ProjectDir)\..\..\..\public\rehlds;$(ProjectDir)\..\..\..\pm_shared;$(ProjectDir)\..\..\..\..\dep\bzip2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/rehlds/HLTV/Core/src/World.h
+++ b/rehlds/HLTV/Core/src/World.h
@@ -252,11 +252,11 @@ protected:
 
 	int m_MaxInstanced_BaseLine;
 
-#ifdef HOOK_HLTV
-	char m_Lightstyles[MAX_LIGHTSTYLES][65];
-#else
+#if defined(HLTV_FIXES) && !defined(HOOK_HLTV)
 	char m_Lightstyles[MAX_LIGHTSTYLES][64];
-#endif // HOOK_HLTV
+#else
+	char m_Lightstyles[MAX_LIGHTSTYLES][65];
+#endif
 
 	movevars_t m_MoveVars;
 	BSPModel m_WorldModel;

--- a/rehlds/HLTV/DemoPlayer/build.gradle
+++ b/rehlds/HLTV/DemoPlayer/build.gradle
@@ -16,7 +16,7 @@ void setupToolchain(NativeBinarySpec b) {
 	boolean useGcc = project.hasProperty("useGcc")
 	def cfg = rootProject.createToolchainConfig(b);
 	cfg.projectInclude(project, '/..', '/../..', '/src', '/../common', '/../../common', '/../../engine', '/../../public', '/../../public/rehlds', '/../../pm_shared');
-	cfg.singleDefines 'USE_BREAKPAD_HANDLER', 'HLTV', 'DEMOPLAYER_MODULE'
+	cfg.singleDefines 'USE_BREAKPAD_HANDLER', 'HLTV', 'HLTV_FIXES', 'DEMOPLAYER_MODULE'
 
 	if (cfg instanceof MsvcToolchainConfig) {
 		cfg.compilerOptions.pchConfig = new MsvcToolchainConfig.PrecompiledHeadersConfig(

--- a/rehlds/HLTV/DemoPlayer/msvc/DemoPlayer.vcxproj
+++ b/rehlds/HLTV/DemoPlayer/msvc/DemoPlayer.vcxproj
@@ -125,7 +125,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>HLTV;WIN32;_DEBUG;_WINDOWS;_USRDLL;DEMOPLAYER_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HLTV;HLTV_FIXES;WIN32;_DEBUG;_WINDOWS;_USRDLL;DEMOPLAYER_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(ProjectDir)\..\src;$(ProjectDir)\..\..\;$(ProjectDir)\..\..\..\;$(ProjectDir)\..\..\..\common;$(ProjectDir)\..\..\..\engine;$(ProjectDir)\..\..\..\public;$(ProjectDir)\..\..\..\public\rehlds;$(ProjectDir)\..\..\..\pm_shared;$(ProjectDir)\..\..\..\game_shared;$(ProjectDir)\..\..\..\..\dep\bzip2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -155,7 +155,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HLTV;WIN32;NDEBUG;_WINDOWS;_USRDLL;DEMOPLAYER_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitiHOOons)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HLTV;HLTV_FIXES;WIN32;NDEBUG;_WINDOWS;_USRDLL;DEMOPLAYER_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitiHOOons)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(ProjectDir)\..\src;$(ProjectDir)\..\..\;$(ProjectDir)\..\..\..\;$(ProjectDir)\..\..\..\common;$(ProjectDir)\..\..\..\engine;$(ProjectDir)\..\..\..\public;$(ProjectDir)\..\..\..\public\rehlds;$(ProjectDir)\..\..\..\pm_shared;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/rehlds/HLTV/Director/build.gradle
+++ b/rehlds/HLTV/Director/build.gradle
@@ -16,7 +16,7 @@ void setupToolchain(NativeBinarySpec b) {
 	boolean useGcc = project.hasProperty("useGcc")
 	def cfg = rootProject.createToolchainConfig(b);
 	cfg.projectInclude(project, '/..', '/../..', '/src', '/../../common', '/../../engine', '/../../public', '/../../public/rehlds', '/../../pm_shared');
-	cfg.singleDefines 'USE_BREAKPAD_HANDLER', 'HLTV', 'DIRECTOR_MODULE'
+	cfg.singleDefines 'USE_BREAKPAD_HANDLER', 'HLTV', 'HLTV_FIXES', 'DIRECTOR_MODULE'
 
 	if (cfg instanceof MsvcToolchainConfig) {
 		cfg.compilerOptions.pchConfig = new MsvcToolchainConfig.PrecompiledHeadersConfig(

--- a/rehlds/HLTV/Director/msvc/Director.vcxproj
+++ b/rehlds/HLTV/Director/msvc/Director.vcxproj
@@ -76,7 +76,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>HLTV;WIN32;_DEBUG;_WINDOWS;_USRDLL;DIRECTOR_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HLTV;HLTV_FIXES;WIN32;_DEBUG;_WINDOWS;_USRDLL;DIRECTOR_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)\..\..\;$(ProjectDir)\..\src;$(ProjectDir)\..\..\..\common;$(ProjectDir)\..\..\..\engine;$(ProjectDir)\..\..\..\public;$(ProjectDir)\..\..\..\public\rehlds;$(ProjectDir)\..\..\..\pm_shared;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -107,7 +107,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HLTV;WIN32;NDEBUG;_WINDOWS;_USRDLL;DIRECTOR_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HLTV;HLTV_FIXES;WIN32;NDEBUG;_WINDOWS;_USRDLL;DIRECTOR_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)\..\..\;$(ProjectDir)\..\src;$(ProjectDir)\..\..\..\common;$(ProjectDir)\..\..\..\engine;$(ProjectDir)\..\..\..\public;$(ProjectDir)\..\..\..\public\rehlds;$(ProjectDir)\..\..\..\pm_shared;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/rehlds/HLTV/Proxy/build.gradle
+++ b/rehlds/HLTV/Proxy/build.gradle
@@ -16,6 +16,8 @@ project.ext.dep_bzip2 = project(':dep/bzip2')
 
 void setupToolchain(NativeBinarySpec b) {
 	boolean useGcc = project.hasProperty("useGcc")
+	boolean rehltvFixes = b.flavor.name.contains('rehltvFixes')
+
 	def cfg = rootProject.createToolchainConfig(b);
 	cfg.projectInclude(project, '/..', '/../..', '/src', '/../Director/src', '/../../common', '/../../engine', '/../../public', '/../../public/rehlds', '/../../pm_shared');
 	cfg.projectInclude(dep_bzip2, '/include')
@@ -62,6 +64,10 @@ void setupToolchain(NativeBinarySpec b) {
 		cfg.compilerOptions.args '-fno-exceptions'
 		cfg.projectLibpath(project, '/../../lib/linux32')
 		cfg.extraLibs "steam_api"
+	}
+
+	if (rehltvFixes) {
+		cfg.singleDefines 'REHLTV_FIXES', 'REHLTV_CHECKS'
 	}
 
 	ToolchainConfigUtils.apply(project, cfg, b);

--- a/rehlds/HLTV/Proxy/build.gradle
+++ b/rehlds/HLTV/Proxy/build.gradle
@@ -16,13 +16,12 @@ project.ext.dep_bzip2 = project(':dep/bzip2')
 
 void setupToolchain(NativeBinarySpec b) {
 	boolean useGcc = project.hasProperty("useGcc")
-	boolean rehltvFixes = b.flavor.name.contains('rehltvFixes')
 
 	def cfg = rootProject.createToolchainConfig(b);
 	cfg.projectInclude(project, '/..', '/../..', '/src', '/../Director/src', '/../../common', '/../../engine', '/../../public', '/../../public/rehlds', '/../../pm_shared');
 	cfg.projectInclude(dep_bzip2, '/include')
 
-	cfg.singleDefines 'USE_BREAKPAD_HANDLER', 'HLTV', 'CORE_MODULE'
+	cfg.singleDefines 'USE_BREAKPAD_HANDLER', 'HLTV', 'HLTV_FIXES', 'PROXY_MODULE'
 
 	if (cfg instanceof MsvcToolchainConfig) {
 		cfg.compilerOptions.pchConfig = new MsvcToolchainConfig.PrecompiledHeadersConfig(
@@ -64,10 +63,6 @@ void setupToolchain(NativeBinarySpec b) {
 		cfg.compilerOptions.args '-fno-exceptions'
 		cfg.projectLibpath(project, '/../../lib/linux32')
 		cfg.extraLibs "steam_api"
-	}
-
-	if (rehltvFixes) {
-		cfg.singleDefines 'REHLTV_FIXES', 'REHLTV_CHECKS'
 	}
 
 	ToolchainConfigUtils.apply(project, cfg, b);

--- a/rehlds/HLTV/Proxy/msvc/Proxy.vcxproj
+++ b/rehlds/HLTV/Proxy/msvc/Proxy.vcxproj
@@ -384,7 +384,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>HLTV;WIN32;_DEBUG;_WINDOWS;_USRDLL;PROXY_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HLTV;HLTV_FIXES;WIN32;_DEBUG;_WINDOWS;_USRDLL;PROXY_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)\..\src;$(ProjectDir)\..\..\;$(ProjectDir)\..\..\..\;$(ProjectDir)\..\..\Director\src;$(ProjectDir)\..\..\..\common;$(ProjectDir)\..\..\..\engine;$(ProjectDir)\..\..\..\public;$(ProjectDir)\..\..\..\public\rehlds;$(ProjectDir)\..\..\..\pm_shared;$(ProjectDir)\..\..\..\..\dep\bzip2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -418,7 +418,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>HLTV;WIN32;NDEBUG;_WINDOWS;_USRDLL;PROXY_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>HLTV;HLTV_FIXES;WIN32;NDEBUG;_WINDOWS;_USRDLL;PROXY_MODULE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(ProjectDir)\..\src;$(ProjectDir)\..\..\;$(ProjectDir)\..\..\..\;$(ProjectDir)\..\..\Director\src;$(ProjectDir)\..\..\..\common;$(ProjectDir)\..\..\..\engine;$(ProjectDir)\..\..\..\public;$(ProjectDir)\..\..\..\public\rehlds;$(ProjectDir)\..\..\..\pm_shared;$(ProjectDir)\..\..\..\..\dep\bzip2\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>precompiled.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/rehlds/HLTV/common/BitBuffer.h
+++ b/rehlds/HLTV/common/BitBuffer.h
@@ -41,7 +41,6 @@ public:
 	unsigned char *CurrentByte();
 
 	int GetMaxSize() const { return m_MaxSize; }
-	unsigned int GetCurSize() const { return m_CurSize; }
 	unsigned char *GetData() const { return m_Data; }
 	bool IsOverflowed() const { return m_Overflowed; }
 
@@ -108,7 +107,7 @@ public:
 	bool m_Overflowed;
 	unsigned char *m_Data;
 	unsigned char *m_CurByte;
-	int m_CurSize;
+	int m_CurBit;
 	int m_MaxSize;
 
 protected:

--- a/rehlds/HLTV/common/InfoString.cpp
+++ b/rehlds/HLTV/common/InfoString.cpp
@@ -81,7 +81,7 @@ bool InfoString::SetString(char *string)
 		return false;
 	}
 
-	Q_strnlcpy(m_String, string, m_MaxSize);
+	Q_strlcpy(m_String, string, m_MaxSize);
 	return true;
 }
 
@@ -95,7 +95,7 @@ void InfoString::SetMaxSize(unsigned int maxSize)
 	if (m_String)
 	{
 		if (maxSize > Q_strlen(m_String)) {
-			Q_strnlcpy(newBuffer, m_String, maxSize);
+			Q_strlcpy(newBuffer, m_String, maxSize);
 		}
 
 		Mem_Free(m_String);

--- a/rehlds/HLTV/common/NetChannel.cpp
+++ b/rehlds/HLTV/common/NetChannel.cpp
@@ -310,7 +310,12 @@ void NetChannel::UpdateFlow(int stream)
 
 void NetChannel::TransmitOutgoing()
 {
+#ifdef HLTV_FIXES
+	byte send_buf[MAX_UDP_PACKET];
+#else
 	byte send_buf[NET_MAX_MESSAGE];
+#endif
+
 	BitBuffer data(send_buf, sizeof(send_buf));
 
 	bool send_reliable;
@@ -336,7 +341,7 @@ void NetChannel::TransmitOutgoing()
 	// check for reliable message overflow
 	if (m_reliableStream.IsOverflowed())
 	{
-		m_System->DPrintf("Transmit:Outgoing m_reliableStream overflow (%s)\n", m_remote_address.ToString());
+		m_System->DPrintf("NetChannel::Transmit:Outgoing m_reliableStream overflow (%s)\n", m_remote_address.ToString());
 		m_reliableStream.Clear();
 		return;
 	}
@@ -344,7 +349,7 @@ void NetChannel::TransmitOutgoing()
 	// check for unreliable message overflow
 	if (m_unreliableStream.IsOverflowed())
 	{
-		m_System->DPrintf("Transmit:Outgoing m_unreliableStream overflow (%s)\n", m_remote_address.ToString());
+		m_System->DPrintf("NetChannel::Transmit:Outgoing m_unreliableStream overflow (%s)\n", m_remote_address.ToString());
 		m_unreliableStream.Clear();
 	}
 
@@ -653,8 +658,7 @@ bool NetChannel::CheckForCompletion(int stream, int intotalbuffers)
 	return false;
 }
 
-#ifdef REHLTV_FIXES
-bool NetChannel::ValidateFragments(int pkt_size, qboolean *frag_message, unsigned int *fragid, int *frag_offset, int *frag_length)
+bool NetChannel::ValidateFragments(BitBuffer &buf, bool *frag_message, unsigned int *fragid, int *frag_offset, int *frag_length)
 {
 	for (int i = 0; i < MAX_STREAMS; i++)
 	{
@@ -664,32 +668,35 @@ bool NetChannel::ValidateFragments(int pkt_size, qboolean *frag_message, unsigne
 		// total fragments should be <= MAX_FRAGMENTS and current fragment can't be > total fragments
 		if (i == FRAG_NORMAL_STREAM && FRAG_GETCOUNT(fragid[i]) > MAX_NORMAL_FRAGMENTS)
 			return false;
+
 		if (i == FRAG_FILE_STREAM && FRAG_GETCOUNT(fragid[i]) > MAX_FILE_FRAGMENTS)
 			return false;
+
 		if (FRAG_GETID(fragid[i]) > FRAG_GETCOUNT(fragid[i]))
 			return false;
+
 		if (!frag_length[i])
 			return false;
+
 		if ((size_t)frag_length[i] > FRAGMENT_MAX_SIZE || (size_t)frag_offset[i] > MAX_POSSIBLE_MSG - 1)
 			return false;
 
 		int frag_end = frag_offset[i] + frag_length[i];
 
 		// end of fragment is out of the packet
-		if (frag_end + msg_readcount > pkt_size)
+		if (frag_end + buf.CurrentSize() > buf.GetMaxSize())
 			return false;
 
 		// fragment overlaps next stream's fragment or placed after it
 		for (int j = i + 1; j < MAX_STREAMS; j++)
 		{
-			if (frag_end > frag_offset[j] && frag_message[j]) // don't add msg_readcount for comparison
+			if (frag_end > frag_offset[j] && frag_message[j]) // don't add buf.CurrentSize() for comparison
 				return false;
 		}
 	}
 
 	return true;
 }
-#endif // REHLTV_FIXES
 
 void NetChannel::ProcessIncoming(unsigned char *data, int size)
 {
@@ -760,8 +767,8 @@ void NetChannel::ProcessIncoming(unsigned char *data, int size)
 			}
 		}
 
-#ifdef REHLTV_FIXES
-		if (!ValidateFragments(size, frag_message, fragid, frag_offset, frag_length))
+#ifdef HLTV_FIXES
+		if (!ValidateFragments(message, frag_message, fragid, frag_offset, frag_length))
 			return;
 #endif
 	}
@@ -801,7 +808,12 @@ void NetChannel::ProcessIncoming(unsigned char *data, int size)
 	// clear the buffer to make way for the next
 	if (reliable_ack == (unsigned int)m_reliable_sequence)
 	{
+		// Make sure we actually could have ack'd this message
+#ifdef HLTV_FIXES
+		if (sequence_ack >= (unsigned)m_last_reliable_sequence)
+#else
 		if (m_incoming_acknowledged + 1 >= m_last_reliable_sequence)
+#endif
 		{
 			// it has been received
 			m_reliableOutSize = 0;
@@ -1146,6 +1158,24 @@ void NetChannel::CopyNormalFragments()
 		Mem_Free(p);
 		p = n;
 	}
+
+#ifdef HLTV_FIXES
+	if (packet->data.IsOverflowed())
+	{
+		if (packet->address.IsValid())
+		{
+			m_System->Printf("WARNING! NetChannel::CopyNormalFragments: Incoming overflowed from %s\n", packet->address.ToString());
+		}
+		else
+		{
+			m_System->Printf("WARNING! NetChannel::CopyNormalFragments: Incoming overflowed\n");
+		}
+
+		packet->data.Clear();
+		m_incomingbufs[FRAG_NORMAL_STREAM] = nullptr;
+		return;
+	}
+#endif
 
 	if (*(uint32 *)packet->data.GetData() == MAKEID('B', 'Z', '2', '\0'))
 	{

--- a/rehlds/HLTV/common/NetChannel.h
+++ b/rehlds/HLTV/common/NetChannel.h
@@ -51,41 +51,41 @@ enum
 	MAX_FLOWS
 };
 
-#define MAX_LATENT				32
-#define FRAGMENT_MAX_SIZE		1400		// Size of fragmentation buffer internal buffers
-#define CLIENT_FRAGMENT_SIZE_ONCONNECT	128
-#define CUSTOMIZATION_MAX_SIZE	20480
+#define MAX_LATENT                     32
+#define FRAGMENT_MAX_SIZE              1400		// Size of fragmentation buffer internal buffers
+#define CLIENT_FRAGMENT_SIZE_ONCONNECT 128
+#define CUSTOMIZATION_MAX_SIZE         20480
 
 // Client sends normal fragments only while connecting
-#define MAX_NORMAL_FRAGMENTS (MAX_POSSIBLE_MSG / CLIENT_FRAGMENT_SIZE_ONCONNECT)
+#define MAX_NORMAL_FRAGMENTS           (MAX_POSSIBLE_MSG / CLIENT_FRAGMENT_SIZE_ONCONNECT)
 
 // While client is connecting it sending fragments with minimal size, also it transfers sprays with minimal fragments...
 // But with sv_delayed_spray_upload it sends with cl_dlmax fragment size
-#define MAX_FILE_FRAGMENTS (CUSTOMIZATION_MAX_SIZE / FRAGMENT_C2S_MIN_SIZE)
+#define MAX_FILE_FRAGMENTS             (CUSTOMIZATION_MAX_SIZE / FRAGMENT_C2S_MIN_SIZE)
 
-#define UDP_HEADER_SIZE			28
-#define MAX_RELIABLE_PAYLOAD	1200
+#define UDP_HEADER_SIZE                28
+#define MAX_RELIABLE_PAYLOAD           1200
 
-#define MAKE_FRAGID(id, count)	(((id & 0xffff) << 16) | (count & 0xffff))
-#define FRAG_GETID(fragid)		((fragid >> 16) & 0xffff)
-#define FRAG_GETCOUNT(fragid)	(fragid & 0xffff)
+#define MAKE_FRAGID(id, count)         (((id & 0xffff) << 16) | (count & 0xffff))
+#define FRAG_GETID(fragid)             ((fragid >> 16) & 0xffff)
+#define FRAG_GETCOUNT(fragid)          (fragid & 0xffff)
 
 // Max length of a reliable message
-#define	MAX_MSGLEN				3990		// 10 reserved for fragheader?
-#define MAX_POSSIBLE_MSG		65536
+#define MAX_MSGLEN                     3990		// 10 reserved for fragheader?
+#define MAX_POSSIBLE_MSG               65536
 
-#define MAX_ROUTEABLE_PACKET	1400
-#define MIN_ROUTEABLE_PACKET	16
+#define MAX_ROUTEABLE_PACKET           1400
+#define MIN_ROUTEABLE_PACKET           16
 
-#define SPLIT_SIZE				(MAX_ROUTEABLE_PACKET - sizeof(SPLITPACKET))
+#define SPLIT_SIZE                     (MAX_ROUTEABLE_PACKET - sizeof(SPLITPACKET))
 
 // Pad this to next higher 16 byte boundary
 // This is the largest packet that can come in/out over the wire, before processing the header
 // bytes will be stripped by the networking channel layer
 // #define NET_MAX_MESSAGE PAD_NUMBER( ( MAX_MSGLEN + HEADER_BYTES ), 16 )
 // This is currently used value in the engine. TODO: define above gives 4016, check it why.
-#define NET_MAX_MESSAGE 4037
-#define NET_HEADER_FLAG_SPLITPACKET -2
+#define NET_MAX_MESSAGE                4037
+#define NET_HEADER_FLAG_SPLITPACKET    -2
 
 class IBaseSystem;
 
@@ -125,7 +125,7 @@ public:
 	typedef struct flowstats_s
 	{
 		int size;		// Size of message sent/received
-		double time;		// Time that message was sent/received
+		double time;	// Time that message was sent/received
 	} flowstats_t;
 
 	typedef struct flow_s
@@ -143,27 +143,25 @@ public:
 	typedef struct fragbuf_s
 	{
 		struct fragbuf_s *next;			// Next buffer in chain
-		int bufferId;				// Id of this buffer
-		byte data[FRAGMENT_MAX_SIZE];		// The actual data sits here
+		int bufferId;					// Id of this buffer
+		byte data[FRAGMENT_MAX_SIZE];	// The actual data sits here
 
-		int size;				// Size of data to read at that offset
-		bool isfile;				// Is this a file buffer?
-		bool isbuffer;				// Is this file buffer from memory ( custom decal, etc. ).
+		int size;						// Size of data to read at that offset
+		bool isfile;					// Is this a file buffer?
+		bool isbuffer;					// Is this file buffer from memory ( custom decal, etc. ).
 		char fileName[MAX_PATH];		// Name of the file to save out on remote host
-		int fOffset;				// Offset in file from which to read data
+		int fOffset;					// Offset in file from which to read data
 	} fragbuf_t;
 
 	// Waiting list of fragbuf chains
 	typedef struct fragbufwaiting_s
 	{
-		struct fragbufwaiting_s *next;		// Next chain in waiting list
-		int fragbufcount;			// Number of buffers in this chain
+		struct fragbufwaiting_s *next;	// Next chain in waiting list
+		int fragbufcount;				// Number of buffers in this chain
 		fragbuf_t *fragbufs;			// The actual buffers
 	} fragbufwaiting_t;
 
-#ifdef REHLTV_FIXES
-	bool ValidateFragments(int pkt_size, qboolean *frag_message, unsigned int *fragid, int *frag_offset, int *frag_length);
-#endif
+	bool ValidateFragments(BitBuffer &buf, bool *frag_message, unsigned int *fragid, int *frag_offset, int *frag_length);
 	bool CreateFragmentsFromFile(char *fileName);
 	bool CopyFileFragments();
 	void GetFlowStats(float *avgInKBSec, float *avgOutKBSec);
@@ -191,25 +189,25 @@ public:
 	NetAddress m_remote_address;		// Address this channel is talking to.
 	double m_last_received;
 	double m_last_send;
-	double m_connect_time;			// Time when channel was connected.
+	double m_connect_time;				// Time when channel was connected.
 	float m_timeout;
 	int m_max_bandwidth_rate;
 	double m_send_interval;
-	int m_updaterate;			// Bandwidth choke, bytes per second
-	double m_cleartime;			// If realtime > cleartime, free to send next packet
+	int m_updaterate;					// Bandwidth choke, bytes per second
+	double m_cleartime;					// If realtime > cleartime, free to send next packet
 
 	bool m_keep_alive;
 	bool m_crashed;
 	bool m_connected;
 
 	// Sequencing variables
-	int m_incoming_sequence;		// Increasing count of sequence numbers
-	int m_incoming_acknowledged;		// # of last outgoing message that has been ack'd.
+	int m_incoming_sequence;				// Increasing count of sequence numbers
+	int m_incoming_acknowledged;			// # of last outgoing message that has been ack'd.
 	int m_incoming_reliable_acknowledged;	// Toggles T/F as reliable messages are received.
-	int m_incoming_reliable_sequence;	// single bit, maintained local
-	int m_outgoing_sequence;		// Message we are sending to remote
-	int m_reliable_sequence;		// Whether the message contains reliable payload, single bit
-	int m_last_reliable_sequence;		// Outgoing sequence number of last send that had reliable data
+	int m_incoming_reliable_sequence;		// single bit, maintained local
+	int m_outgoing_sequence;				// Message we are sending to remote
+	int m_reliable_sequence;				// Whether the message contains reliable payload, single bit
+	int m_last_reliable_sequence;			// Outgoing sequence number of last send that had reliable data
 
 	void *m_connection_status;
 
@@ -228,11 +226,11 @@ public:
 	int m_reliable_fragment[MAX_STREAMS];			// Is reliable waiting buf a fragment?
 	size_t m_reliable_fragid[MAX_STREAMS];			// Buffer id for each waiting fragment
 
-	fragbuf_t *m_fragbufs[MAX_STREAMS];			// The current fragment being set
-	int m_fragbufcount[MAX_STREAMS];			// The total number of fragments in this stream
+	fragbuf_t *m_fragbufs[MAX_STREAMS];				// The current fragment being set
+	int m_fragbufcount[MAX_STREAMS];				// The total number of fragments in this stream
 
-	int16 m_frag_startpos[MAX_STREAMS];			// Position in outgoing buffer where frag data starts
-	int16 m_frag_length[MAX_STREAMS];			// Length of frag data in the buffer
+	int16 m_frag_startpos[MAX_STREAMS];				// Position in outgoing buffer where frag data starts
+	int16 m_frag_length[MAX_STREAMS];				// Length of frag data in the buffer
 
 	fragbuf_t *m_incomingbufs[MAX_STREAMS];			// Incoming fragments are stored here
 

--- a/rehlds/HLTV/common/NetChannel.h
+++ b/rehlds/HLTV/common/NetChannel.h
@@ -53,6 +53,15 @@ enum
 
 #define MAX_LATENT				32
 #define FRAGMENT_MAX_SIZE		1400		// Size of fragmentation buffer internal buffers
+#define CLIENT_FRAGMENT_SIZE_ONCONNECT	128
+#define CUSTOMIZATION_MAX_SIZE	20480
+
+// Client sends normal fragments only while connecting
+#define MAX_NORMAL_FRAGMENTS (MAX_POSSIBLE_MSG / CLIENT_FRAGMENT_SIZE_ONCONNECT)
+
+// While client is connecting it sending fragments with minimal size, also it transfers sprays with minimal fragments...
+// But with sv_delayed_spray_upload it sends with cl_dlmax fragment size
+#define MAX_FILE_FRAGMENTS (CUSTOMIZATION_MAX_SIZE / FRAGMENT_C2S_MIN_SIZE)
 
 #define UDP_HEADER_SIZE			28
 #define MAX_RELIABLE_PAYLOAD	1200
@@ -152,6 +161,9 @@ public:
 		fragbuf_t *fragbufs;			// The actual buffers
 	} fragbufwaiting_t;
 
+#ifdef REHLTV_FIXES
+	bool ValidateFragments(int pkt_size, qboolean *frag_message, unsigned int *fragid, int *frag_offset, int *frag_length);
+#endif
 	bool CreateFragmentsFromFile(char *fileName);
 	bool CopyFileFragments();
 	void GetFlowStats(float *avgInKBSec, float *avgOutKBSec);

--- a/rehlds/build.gradle
+++ b/rehlds/build.gradle
@@ -114,6 +114,7 @@ void setupToolchain(NativeBinarySpec b) {
 	boolean unitTestExecutable = b.component.name.endsWith('_tests')
 	boolean swdsLib = b.name.toLowerCase().contains('swds')
 	boolean rehldsFixes = b.flavor.name.contains('rehldsFixes')
+	boolean release = b.buildType.name.toLowerCase() == 'release';
 
 	ToolchainConfig cfg = rootProject.createToolchainConfig(b)
 	cfg.projectInclude(project, '', '/public/rehlds', '/engine', '/common', '/pm_shared', '/rehlds', '/testsuite', '/hookers', '/public')
@@ -125,7 +126,7 @@ void setupToolchain(NativeBinarySpec b) {
 	}
 	b.lib LazyNativeDepSet.create(dep_bzip2, 'bzip2', b.buildType.name, true)
 
-	cfg.singleDefines 'USE_BREAKPAD_HANDLER', 'DEDICATED', 'SWDS', 'REHLDS_SELF', 'REHLDS_OPT_PEDANTIC', 'REHLDS_FLIGHT_REC', 'REHLDS_API'
+	cfg.singleDefines 'USE_BREAKPAD_HANDLER', 'DEDICATED', 'SWDS', 'REHLDS_SELF', 'REHLDS_OPT_PEDANTIC', 'REHLDS_API'
 
 	if (cfg instanceof MsvcToolchainConfig) {
 		cfg.compilerOptions.pchConfig = new MsvcToolchainConfig.PrecompiledHeadersConfig(
@@ -185,6 +186,10 @@ void setupToolchain(NativeBinarySpec b) {
 
 	if (rehldsFixes) {
 		cfg.singleDefines 'REHLDS_FIXES', 'REHLDS_SSE', 'REHLDS_JIT', 'REHLDS_CHECKS', 'HAVE_OPT_STRTOOLS'
+	}
+
+	if (!release) {
+		cfg.singleDefines 'REHLDS_FLIGHT_REC'
 	}
 
 	ToolchainConfigUtils.apply(project, cfg, b)

--- a/rehlds/common/port.h
+++ b/rehlds/common/port.h
@@ -105,7 +105,7 @@
 	extern char g_szEXEName[ 4096 ];
 
 	#define _snprintf snprintf
-	
+
 	#if defined(OSX)
 		#define SO_ARCH_SUFFIX ".dylib"
 	#else

--- a/rehlds/common/port.h
+++ b/rehlds/common/port.h
@@ -105,7 +105,7 @@
 	extern char g_szEXEName[ 4096 ];
 
 	#define _snprintf snprintf
-
+	
 	#if defined(OSX)
 		#define SO_ARCH_SUFFIX ".dylib"
 	#else

--- a/rehlds/engine/host_cmd.cpp
+++ b/rehlds/engine/host_cmd.cpp
@@ -2365,16 +2365,55 @@ void Host_Version_f(void)
 
 void Host_FullInfo_f(void)
 {
-	char key[512];
-	char value[512];
-	char *o;
-	char *s;
-
 	if (Cmd_Argc() != 2)
 	{
 		Con_Printf("fullinfo <complete info string>\n");
 		return;
 	}
+
+#ifdef REHLDS_FIXES
+	char copy[MAX_INFO_STRING];
+	Q_strlcpy(copy, Cmd_Argv(1));
+
+	char* s = copy;
+	if (*s != '\\')
+		return;
+
+	bool eos = false;
+	while (!eos) {
+		const char* key = ++s;
+
+		// key
+		while (*s != '\\')
+		{
+			// key should end with a '\', not a NULL
+			if (*s == '\0') {
+				Con_Printf("MISSING VALUE\n");
+				return;
+			}
+
+			s++;
+		}
+
+		*s = '\0';
+		const char* value = ++s;
+
+		// value
+		while (*s != '\\') {
+			if (*s == '\0') {
+				eos = true;
+				break;
+			}
+
+			s++;
+		}
+
+		*s = '\0';
+#else
+	char key[512];
+	char value[512];
+	char *o;
+	char *s;
 
 	s = (char *)Cmd_Argv(1);
 	if (*s == '\\')
@@ -2400,6 +2439,7 @@ void Host_FullInfo_f(void)
 		*o = 0;
 		if (*s)
 			s++;
+#endif
 
 		if (cmd_source == src_command)
 		{

--- a/rehlds/engine/info.cpp
+++ b/rehlds/engine/info.cpp
@@ -31,10 +31,84 @@
 // NOTE: This file contains a lot of fixes that are not covered by REHLDS_FIXES define.
 // TODO: Most of the Info_ functions can be speedup via removing unneded copy of key and values.
 
+struct info_field_t
+{
+	char*	name;
+	bool	integer;
+};
+
+info_field_t g_info_important_fields[] =
+{
+	// name				integer
+	{ "name",			false },
+	{ "model",			false },
+
+	// model colors
+	{ "topcolor",		true },
+	{ "bottomcolor",	true },
+
+	// network
+	{ "rate",			true },
+	{ "cl_updaterate",	true },
+	{ "cl_lw",			true },
+	{ "cl_lc",			true },
+
+	// hltv flag
+	{ "*hltv",			true },
+
+	// avatars
+	{ "*sid",			false }, // transmit as string because it's int64
+
+	// gui/text menus
+	{ "_vgui_menus",	true }
+};
+
+std::vector<info_field_t *> g_info_transmitted_fields;
+
 // Searches the string for the given
 // key and returns the associated value, or an empty string.
-const char* EXT_FUNC Info_ValueForKey(const char *s, const char *key)
+const char* EXT_FUNC Info_ValueForKey(const char *s, const char *lookup)
 {
+#ifdef REHLDS_FIXES
+	static char valueBuf[INFO_MAX_BUFFER_VALUES][MAX_KV_LEN];
+	static int valueIndex;
+
+	while (*s == '\\')
+	{
+		// skip starting slash
+		const char* key = ++s;
+
+		// skip key
+		while (*s != '\\') {
+			// Add some sanity checks because it's external function
+			if (*s == '\0')
+				return "";
+
+			s++;
+		}
+
+		size_t keyLen = s - key;
+		const char* value = ++s; // skip separating slash
+
+		// skip value
+		while (*s != '\\' && *s != '\0')
+			s++;
+
+		size_t valueLen = Q_min(s - value, MAX_KV_LEN - 1);
+
+		if (!Q_strncmp(key, lookup, keyLen))
+		{
+			char* dest = valueBuf[valueIndex];
+			Q_memcpy(dest, value, valueLen);
+			dest[valueLen] = '\0';
+
+			valueIndex = (valueIndex + 1) % INFO_MAX_BUFFER_VALUES;
+			return dest;
+		}
+	}
+
+	return "";
+#else
 	// use few (two?) buffers so compares work without stomping on each other
 	static char value[INFO_MAX_BUFFER_VALUES][MAX_KV_LEN];
 	static int valueindex;
@@ -69,7 +143,7 @@ const char* EXT_FUNC Info_ValueForKey(const char *s, const char *key)
 		*c = 0;
 		s++;	// skip the slash
 
-		// Copy a value
+				// Copy a value
 		nCount = 0;
 		c = value[valueindex];
 		while (*s != '\\')
@@ -88,7 +162,7 @@ const char* EXT_FUNC Info_ValueForKey(const char *s, const char *key)
 		}
 		*c = 0;
 
-		if (!Q_strcmp(key, pkey))
+		if (!Q_strcmp(lookup, pkey))
 		{
 			c = value[valueindex];
 			valueindex = (valueindex + 1) % INFO_MAX_BUFFER_VALUES;
@@ -97,10 +171,47 @@ const char* EXT_FUNC Info_ValueForKey(const char *s, const char *key)
 	}
 
 	return "";
+#endif
 }
 
-void Info_RemoveKey(char *s, const char *key)
+void Info_RemoveKey(char *s, const char *lookup)
 {
+#ifdef REHLDS_FIXES
+	size_t lookupLen = Q_strlen(lookup);
+
+	while (*s == '\\')
+	{
+		char* start = s;
+
+		// skip starting slash
+		const char* key = ++s;
+
+		// skip key
+		while (*s != '\\') {
+			if (*s == '\0')
+				return;
+
+			s++;
+		}
+
+		size_t keyLen = s - key;
+		++s; // skip separating slash
+
+		// skip value
+		while (*s != '\\' && *s != '\0')
+			s++;
+
+		if (keyLen != lookupLen)
+			continue;
+
+		if (!Q_memcmp(key, lookup, lookupLen))
+		{
+			// cut key and value
+			Q_memmove(start, s, Q_strlen(s) + 1);
+			break;
+		}
+	}
+#else
 	char pkey[MAX_KV_LEN];
 	char value[MAX_KV_LEN];
 	char *start;
@@ -108,13 +219,13 @@ void Info_RemoveKey(char *s, const char *key)
 	int cmpsize;
 	int nCount;
 
-	if (Q_strstr(key, "\\"))
+	if (Q_strstr(lookup, "\\"))
 	{
 		Con_Printf("Can't use a key with a \\\n");
 		return;
 	}
 
-	cmpsize = Q_strlen(key);
+	cmpsize = Q_strlen(lookup);
 	if (cmpsize > MAX_KV_LEN - 1)
 		cmpsize = MAX_KV_LEN - 1;
 
@@ -168,16 +279,47 @@ void Info_RemoveKey(char *s, const char *key)
 		*c = 0;
 
 		// Compare keys
-		if (!Q_strncmp(key, pkey, cmpsize))
+		if (!Q_strncmp(lookup, pkey, cmpsize))
 		{
 			Q_strcpy_s(start, s);	// remove this part
 			s = start;	// continue searching
 		}
 	}
+#endif
 }
 
 void Info_RemovePrefixedKeys(char *s, const char prefix)
 {
+#ifdef REHLDS_FIXES
+	while (*s == '\\')
+	{
+		char* start = s;
+
+		// skip starting slash
+		const char* key = ++s;
+
+		// skip key
+		while (*s != '\\') {
+			if (*s == '\0')
+				return;
+
+			s++;
+		}
+
+		// skip separating slash
+		++s;
+
+		// skip value
+		while (*s != '\\' && *s != '\0')
+			s++;
+
+		if (key[0] == prefix)
+		{
+			Q_memmove(start, s, Q_strlen(s) + 1);
+			s = start;
+		}
+	}
+#else
 	char pkey[MAX_KV_LEN];
 	char value[MAX_KV_LEN];
 	char *start;
@@ -239,12 +381,37 @@ void Info_RemovePrefixedKeys(char *s, const char prefix)
 			s = start;	// continue searching
 		}
 	}
+#endif
 }
 
+#ifdef REHLDS_FIXES
 qboolean Info_IsKeyImportant(const char *key)
 {
 	if (key[0] == '*')
 		return true;
+
+	for (auto& field : g_info_important_fields) {
+		if (!Q_strcmp(key, field.name))
+			return true;
+	}
+
+	return false;
+}
+
+qboolean Info_IsKeyImportant(const char *key, size_t keyLen)
+{
+	char copy[MAX_KV_LEN];
+	keyLen = min(keyLen, sizeof(copy) - 1);
+	Q_memcpy(copy, key, keyLen);
+	copy[keyLen] = '\0';
+	return Info_IsKeyImportant(copy);
+}
+#else
+qboolean Info_IsKeyImportant(const char *key)
+{
+	if (key[0] == '*')
+		return true;
+
 	if (!Q_strcmp(key, "name"))
 		return true;
 	if (!Q_strcmp(key, "model"))
@@ -261,19 +428,53 @@ qboolean Info_IsKeyImportant(const char *key)
 		return true;
 	if (!Q_strcmp(key, "cl_lc"))
 		return true;
-#ifndef REHLDS_FIXES
-	// keys starts from '*' already checked
 	if (!Q_strcmp(key, "*hltv"))
 		return true;
 	if (!Q_strcmp(key, "*sid"))
 		return true;
-#endif
 
 	return false;
 }
+#endif
 
-char *Info_FindLargestKey(char *s, int maxsize)
+const char *Info_FindLargestKey(const char *s, int maxsize)
 {
+#ifdef REHLDS_FIXES
+	static char largestKey[MAX_KV_LEN];
+	size_t largestLen = 0;
+
+	while (*s == '\\')
+	{
+		// skip starting slash
+		const char* key = ++s;
+
+		// skip key
+		while (*s != '\\') {
+			if (*s == '\0')
+				return "";
+
+			s++;
+		}
+
+		size_t keyLen = s - key;
+		const char* value = ++s; // skip separating slash
+
+			 // skip value
+		while (*s != '\\' && *s != '\0')
+			s++;
+
+		size_t valueLen = s - value;
+		size_t totalLen = keyLen + valueLen;
+
+		if (totalLen > largestLen && !Info_IsKeyImportant(key, keyLen)) {
+			largestLen = totalLen;
+			Q_memcpy(largestKey, key, keyLen);
+			largestKey[keyLen] = '\0';
+		}
+	}
+
+	return largestLen ? largestKey : "";
+#else
 	static char largest_key[MAX_KV_LEN];
 	char key[MAX_KV_LEN];
 	char value[MAX_KV_LEN];
@@ -347,8 +548,104 @@ char *Info_FindLargestKey(char *s, int maxsize)
 	}
 
 	return largest_key;
+#endif
 }
 
+#ifdef REHLDS_FIXES
+qboolean Info_SetValueForStarKey(char *s, const char *key, const char *value, size_t maxsize)
+{
+	char newArray[MAX_INFO_STRING], valueBuf[MAX_KV_LEN];
+
+	if (!key || !value)
+	{
+		Con_Printf("Keys and values can't be null\n");
+		return FALSE;
+	}
+
+	if (key[0] == '\0')
+	{
+		Con_Printf("Keys can't be an empty string\n");
+		return FALSE;
+	}
+
+	if (Q_strchr(key, '\\') || Q_strchr(value, '\\'))
+	{
+		Con_Printf("Can't use keys or values with a \\\n");
+		return FALSE;
+	}
+
+	if (Q_strchr(key, '\"') || Q_strchr(value, '\"'))
+	{
+		Con_Printf("Can't use keys or values with a \"\n");
+		return FALSE;
+	}
+
+	if (Q_strstr(key, "..") || Q_strstr(value, ".."))
+	{
+		Con_Printf("Can't use keys or values with a ..\n");
+		return FALSE;
+	}
+
+	int keyLen = Q_strlen(key);
+	int valueLen = Q_strlen(value);
+
+	if (keyLen >= MAX_KV_LEN || valueLen >= MAX_KV_LEN)
+	{
+		Con_Printf("Keys and values must be < %i characters\n", MAX_KV_LEN);
+		return FALSE;
+	}
+
+	if (!Q_UnicodeValidate(key) || !Q_UnicodeValidate(value))
+	{
+		Con_Printf("Keys and values must be valid utf8 text\n");
+		return FALSE;
+	}
+
+	// Remove current key/value and return if we doesn't specified to set a value
+	Info_RemoveKey(s, key);
+	if (value[0] == '\0')
+	{
+		return TRUE;
+	}
+
+	// auto lowercase team
+	if (!Q_strcmp(key, "team")) {
+		value = Q_strcpy(valueBuf, value);
+		Q_strlwr(valueBuf);
+	}
+
+	// Create key/value pair
+	size_t neededLength = Q_snprintf(newArray, sizeof newArray, "\\%s\\%s", key, value);
+
+	if (Q_strlen(s) + neededLength >= maxsize)
+	{
+		// no more room in the buffer to add key/value
+		if (!Info_IsKeyImportant(key))
+		{
+			// no room to add setting
+			Con_Printf("Info string length exceeded\n");
+			return FALSE;
+		}
+
+		// keep removing the largest key/values until we have a room
+		do
+		{
+			const char* largekey = Info_FindLargestKey(s, maxsize);
+			if (largekey[0] == '\0')
+			{
+				// no room to add setting
+				Con_Printf("Info string length exceeded\n");
+				return FALSE;
+			}
+			Info_RemoveKey(s, largekey);
+		} while ((int)Q_strlen(s) + neededLength >= maxsize);
+	}
+
+	Q_strcat(s, newArray);
+
+	return TRUE;
+}
+#else
 void Info_SetValueForStarKey(char *s, const char *key, const char *value, int maxsize)
 {
 	char newArray[MAX_INFO_STRING];
@@ -424,7 +721,7 @@ void Info_SetValueForStarKey(char *s, const char *key, const char *value, int ma
 		}
 
 		// keep removing the largest key/values until we have a room
-		char *largekey;
+		const char *largekey;
 		do
 		{
 			largekey = Info_FindLargestKey(s, maxsize);
@@ -453,6 +750,7 @@ void Info_SetValueForStarKey(char *s, const char *key, const char *value, int ma
 	}
 	*s = 0;
 }
+#endif
 
 void Info_SetValueForKey(char *s, const char *key, const char *value, int maxsize)
 {
@@ -541,6 +839,89 @@ void Info_Print(const char *s)
 
 qboolean Info_IsValid(const char *s)
 {
+#ifdef REHLDS_FIXES
+	struct {
+		const char*	start;
+		size_t		len;
+	} existingKeys[MAX_INFO_STRING * 2 / 4];
+	size_t existingKeysNum = 0;
+
+	auto isAlreadyExists = [&](const char* key, size_t len)
+	{
+		for (size_t i = 0; i < existingKeysNum; i++) {
+			if (len == existingKeys[i].len && !Q_memcmp(key, existingKeys[i].start, existingKeys[i].len))
+				return true;
+		}
+		return false;
+	};
+
+	while (*s == '\\')
+	{
+		const char* key = ++s;
+
+		// keys and values are separated by another slash
+		while (*s != '\\')
+		{
+			// key should end with a '\', not a NULL
+			if (*s == '\0')
+				return FALSE;
+	
+			// quotes are deprecated
+			if (*s == '"')
+				return FALSE;
+
+			// ".." deprecated. don't know why. model path?
+			if (*s == '.' && *(s + 1) == '.')
+				return FALSE;
+
+			s++;
+		}
+
+		size_t keyLen = s - key;
+		if (keyLen == 0 || keyLen >= MAX_KV_LEN)
+			return FALSE;
+
+		if (isAlreadyExists(key, keyLen))
+			return FALSE;
+
+		const char* value = ++s; // skip the slash
+
+		// values should be ended by eos or slash
+		while (*s != '\\' && *s != '\0')
+		{
+			// quotes are deprecated
+			if (*s == '"')
+				return FALSE;
+
+			// ".." deprecated
+			if (*s == '.' && *(s + 1) == '.')
+				return FALSE;
+
+			s++;
+		}
+
+		size_t valueLen = s - value;
+		if (valueLen == 0 || valueLen >= MAX_KV_LEN)
+			return FALSE;
+
+		if (*s == '\0')
+			return TRUE;
+
+		if (existingKeysNum == ARRAYSIZE(existingKeys))
+			return FALSE;
+
+		existingKeys[existingKeysNum].start = key;
+		existingKeys[existingKeysNum].len = keyLen;
+		existingKeysNum++;
+	}
+
+	return FALSE;
+#else
+	char key[MAX_KV_LEN];
+	char value[MAX_KV_LEN];
+	char *c;
+	int nCount;
+
 	while (*s)
 	{
 		if (*s == '\\')
@@ -548,48 +929,46 @@ qboolean Info_IsValid(const char *s)
 			s++;	// skip the slash
 		}
 
-		// Returns character count
-		// -1 - error
-		//  0 - string size is zero
-		enum class AllowNull {
-			Yes,
-			No,
-		};
-		auto validate = [&s](AllowNull allowNull) -> int
+		// Copy a key
+		nCount = 0;
+		c = key;
+		while (*s != '\\')
 		{
-			int nCount = 0;
-
-			for(; *s != '\\'; nCount++, s++)
+			if (!*s)
 			{
-				if (!*s)
-				{
-					return (allowNull == AllowNull::Yes) ? nCount : -1;
-				}
-
-				if (nCount >= MAX_KV_LEN)
-				{
-					return -1;		// string length should be less then MAX_KV_LEN
-				}
-
-#ifdef REHLDS_FIXES
-				if (*s == '\"')
-				{
-					return -1; // string should not contain "
-				}
-#endif
+				return FALSE;		// key should end with a \, not a NULL
 			}
-			return nCount;
-		};
-
-		if (validate(AllowNull::No) == -1)
-		{
-			return FALSE;
+			if (nCount >= MAX_KV_LEN)
+			{
+				return FALSE;		// key length should be less then MAX_KV_LEN
+			}
+			*c++ = *s++;
+			nCount++;
 		}
-		s++; // Skip slash
+		*c = 0;
+		s++;	// skip the slash
 
-		if (validate(AllowNull::Yes) <= 0)
+				// Copy a value
+		nCount = 0;
+		c = value;
+		while (*s != '\\')
 		{
-			return FALSE;
+			if (!*s)
+			{
+				break;				// allow value to be ended with NULL
+			}
+			if (nCount >= MAX_KV_LEN)
+			{
+				return FALSE;		// value length should be less then MAX_KV_LEN
+			}
+			*c++ = *s++;
+			nCount++;
+		}
+		*c = 0;
+
+		if (value[0] == 0)
+		{
+			return FALSE;	// empty values are not valid
 		}
 
 		if (!*s)
@@ -599,52 +978,89 @@ qboolean Info_IsValid(const char *s)
 	}
 
 	return FALSE;
+#endif
 }
 
 #ifdef REHLDS_FIXES
-void Info_CollectFields(char *destInfo, const char *srcInfo, const char *collectedKeysOfFields)
+void Info_SetFieldsToTransmit()
 {
-	char keys[MAX_INFO_STRING];
-	Q_strcpy(keys, collectedKeysOfFields);
+	// clean all
+	for (auto field : g_info_transmitted_fields) {
+		free(field->name);
+		delete field;
+	}
+	g_info_transmitted_fields.clear();
 
-	size_t userInfoLength = 0;
-	for (const char *key = strtok(keys, "\\"); key; key = strtok(nullptr, "\\"))
+	char keys[512];
+	Q_strlcpy(keys, sv_rehlds_userinfo_transmitted_fields.string);
+
+	auto isIntegerField = [](const char* key)
 	{
-		const char *value = Info_ValueForKey(srcInfo, key);
+		for (auto& x : g_info_important_fields) {
+			if (!Q_strcmp(key, x.name))
+				return x.integer;
+		}
+		return false;
+	};
 
+	for (char *key = Q_strtok(keys, "\\"); key; key = Q_strtok(nullptr, "\\"))
+	{
+		if (key[0] == '_') {
+			Con_Printf("%s: private key '%s' couldn't be transmitted.\n", __FUNCTION__, key);
+			continue;
+		}
+
+		if (Q_strlen(key) >= MAX_KV_LEN) {
+			Con_Printf("%s: key '%s' is too long (should be < %i characters)\n", __FUNCTION__, key, MAX_KV_LEN);
+			continue;
+		}
+
+		if (std::find_if(g_info_transmitted_fields.begin(), g_info_transmitted_fields.end(), [key](info_field_t* field) { return !Q_strcmp(key, field->name); }) == g_info_transmitted_fields.end()) {
+			auto field = new info_field_t;
+			field->name = Q_strdup(key);
+			field->integer = isIntegerField(key);
+			g_info_transmitted_fields.push_back(field);
+		}
+	}
+}
+
+void Info_CollectFields(char *destInfo, const char *srcInfo, size_t maxsize)
+{
+	if (g_info_transmitted_fields.empty()) {
+		Q_strlcpy(destInfo, srcInfo, maxsize);
+		Info_RemovePrefixedKeys(destInfo, '_');
+		return;
+	}
+
+	char add[512], valueBuf[32];
+	size_t userInfoLength = 0;
+
+	for (auto field : g_info_transmitted_fields)
+	{
+		const char *value = Info_ValueForKey(srcInfo, field->name);
 		if (value[0] == '\0')
 			continue;
 
-		// Integer fields
-		if (!Q_strcmp(key, "*hltv")
-		 || !Q_strcmp(key, "bottomcolor")
-		 || !Q_strcmp(key, "topcolor"))
+		// clean garbage from integer fields
+		if (field->integer)
 		{
+			// don't send zero fields
 			int intValue = Q_atoi(value);
-
 			if (!intValue)
 				continue;
 
-			destInfo[userInfoLength++] = '\\';
-			Q_strcpy(&destInfo[userInfoLength], key);
-			userInfoLength += Q_strlen(key);
-
-			destInfo[userInfoLength++] = '\\';
-			userInfoLength += Q_sprintf(&destInfo[userInfoLength], "%d", intValue);
-		}
-		// String fields
-		else
-		{
-			destInfo[userInfoLength++] = '\\';
-			Q_strcpy(&destInfo[userInfoLength], key);
-			userInfoLength += Q_strlen(key);
-
-			destInfo[userInfoLength++] = '\\';
-			Q_strcpy(&destInfo[userInfoLength], value);
-			userInfoLength += Q_strlen(value);
+			Q_sprintf(valueBuf, "%i", intValue);
+			value = valueBuf;
 		}
 
+		// don't write truncated keys/values
+		size_t len = Q_sprintf(add, "\\%s\\%s", field->name, value);
+		if (userInfoLength + len < maxsize) {
+			Q_strcpy(destInfo + userInfoLength, add);
+			userInfoLength += len;
+		}
 	}
+
 	destInfo[userInfoLength] = '\0';
 }
 #endif // REHLDS_FIXES

--- a/rehlds/engine/info.cpp
+++ b/rehlds/engine/info.cpp
@@ -88,6 +88,7 @@ const char* EXT_FUNC Info_ValueForKey(const char *s, const char *lookup)
 			s++;
 		}
 
+		size_t keyLen = s - key;
 		const char* value = ++s; // skip separating slash
 
 		// skip value
@@ -96,7 +97,7 @@ const char* EXT_FUNC Info_ValueForKey(const char *s, const char *lookup)
 
 		size_t valueLen = Q_min(s - value, MAX_KV_LEN - 1);
 
-		if (!Q_strncmp(key, lookup, lookupLen))
+		if (keyLen == lookupLen && !Q_strncmp(key, lookup, lookupLen))
 		{
 			char* dest = valueBuf[valueIndex];
 			Q_memcpy(dest, value, valueLen);

--- a/rehlds/engine/info.cpp
+++ b/rehlds/engine/info.cpp
@@ -73,6 +73,7 @@ const char* EXT_FUNC Info_ValueForKey(const char *s, const char *lookup)
 	static char valueBuf[INFO_MAX_BUFFER_VALUES][MAX_KV_LEN];
 	static int valueIndex;
 
+	size_t lookupLen = Q_strlen(lookup);
 	while (*s == '\\')
 	{
 		// skip starting slash
@@ -87,7 +88,6 @@ const char* EXT_FUNC Info_ValueForKey(const char *s, const char *lookup)
 			s++;
 		}
 
-		size_t keyLen = s - key;
 		const char* value = ++s; // skip separating slash
 
 		// skip value
@@ -96,7 +96,7 @@ const char* EXT_FUNC Info_ValueForKey(const char *s, const char *lookup)
 
 		size_t valueLen = Q_min(s - value, MAX_KV_LEN - 1);
 
-		if (!Q_strncmp(key, lookup, keyLen))
+		if (!Q_strncmp(key, lookup, lookupLen))
 		{
 			char* dest = valueBuf[valueIndex];
 			Q_memcpy(dest, value, valueLen);
@@ -865,7 +865,7 @@ qboolean Info_IsValid(const char *s)
 			// key should end with a '\', not a NULL
 			if (*s == '\0')
 				return FALSE;
-	
+
 			// quotes are deprecated
 			if (*s == '"')
 				return FALSE;

--- a/rehlds/engine/info.h
+++ b/rehlds/engine/info.h
@@ -48,11 +48,16 @@ const char *Info_ValueForKey(const char *s, const char *key);
 void Info_RemoveKey(char *s, const char *key);
 void Info_RemovePrefixedKeys(char *s, const char prefix);
 qboolean Info_IsKeyImportant(const char *key);
-char *Info_FindLargestKey(char *s, int maxsize);
+const char *Info_FindLargestKey(const char *s, int maxsize);
+#ifdef REHLDS_FIXES
+qboolean Info_SetValueForStarKey(char *s, const char *key, const char *value, size_t maxsize);
+#else
 void Info_SetValueForStarKey(char *s, const char *key, const char *value, int maxsize);
+#endif
 void Info_SetValueForKey(char *s, const char *key, const char *value, int maxsize);
 void Info_Print(const char *s);
 qboolean Info_IsValid(const char *s);
 #ifdef REHLDS_FIXES
-void Info_CollectFields(char *destInfo, const char *srcInfo, const char *collectedKeysOfFields);
+void Info_SetFieldsToTransmit();
+void Info_CollectFields(char *destInfo, const char *srcInfo, size_t maxsize);
 #endif

--- a/rehlds/engine/pr_cmds.cpp
+++ b/rehlds/engine/pr_cmds.cpp
@@ -1345,7 +1345,6 @@ void EXT_FUNC EV_SV_Playback(int flags, int clientindex, unsigned short eventind
 	EV_Playback(flags,pEdict, eventindex, delay, origin, angles, fparam1, fparam2, iparam1, iparam2, bparam1, bparam2);
 }
 
-#ifdef REHLDS_FIXES
 int SV_LookupModelIndex(const char *name)
 {
 	if (!name || !name[0])
@@ -1369,7 +1368,6 @@ int SV_LookupModelIndex(const char *name)
 
 	return 0;
 }
-#endif // REHLDS_FIXES
 
 int EXT_FUNC PF_precache_model_I(const char *s)
 {

--- a/rehlds/engine/pr_cmds.h
+++ b/rehlds/engine/pr_cmds.h
@@ -79,6 +79,7 @@ void PF_setsize_I(edict_t *e, const float *rgflMin, const float *rgflMax);
 void PF_setmodel_I(edict_t *e, const char *m);
 int PF_modelindex(const char *pstr);
 int ModelFrames(int modelIndex);
+int SV_LookupModelIndex(const char *name);
 void PF_bprint(char *s);
 void PF_sprint(char *s, int entnum);
 void ServerPrint(const char *szMsg);

--- a/rehlds/engine/pr_edict.cpp
+++ b/rehlds/engine/pr_edict.cpp
@@ -265,6 +265,35 @@ char *ED_ParseEdict(char *data, edict_t *ent)
 
 				Q_strcpy(keyname, "angles");
 			}
+#ifdef REHLDS_FIXES
+			else if (!Q_strcmp(keyname, "model"))
+			{
+				// local model?
+				if (com_token[0] == '*')
+				{
+					// find empty slot
+					int i;
+					for (i = 0; i < MAX_MODELS; i++)
+					{
+						if (!g_psv.model_precache[i])
+							break;
+					}
+
+					int index = Q_atoi(com_token + 1);
+
+					g_psv.model_precache[i] = localmodels[index];
+					g_psv.models[i] = Mod_ForName(localmodels[index], FALSE, FALSE);
+					g_psv.model_precache_flags[i] |= RES_FATALIFMISSING;
+
+#ifdef REHLDS_OPT_PEDANTIC
+					{
+						int __itmp = i;
+						g_rehlds_sv.modelsMap.put(g_psv.model_precache[i], __itmp);
+					}
+#endif
+				}
+			}
+#endif
 
 			kvd.szClassName = className;
 			kvd.szKeyName = keyname;

--- a/rehlds/engine/pr_edict.cpp
+++ b/rehlds/engine/pr_edict.cpp
@@ -271,26 +271,30 @@ char *ED_ParseEdict(char *data, edict_t *ent)
 				// local model?
 				if (com_token[0] == '*')
 				{
-					// find empty slot
-					int i;
-					for (i = 0; i < MAX_MODELS; i++)
+					// make sure that local model not pre-cached yet
+					if (!SV_LookupModelIndex(com_token))
 					{
-						if (!g_psv.model_precache[i])
-							break;
-					}
+						// find empty slot
+						int i;
+						for (i = 0; i < MAX_MODELS; i++)
+						{
+							if (!g_psv.model_precache[i])
+								break;
+						}
 
-					int index = Q_atoi(com_token + 1);
+						int index = Q_atoi(com_token + 1);
 
-					g_psv.model_precache[i] = localmodels[index];
-					g_psv.models[i] = Mod_ForName(localmodels[index], FALSE, FALSE);
-					g_psv.model_precache_flags[i] |= RES_FATALIFMISSING;
+						g_psv.model_precache[i] = localmodels[index];
+						g_psv.models[i] = Mod_ForName(localmodels[index], FALSE, FALSE);
+						g_psv.model_precache_flags[i] |= RES_FATALIFMISSING;
 
 #ifdef REHLDS_OPT_PEDANTIC
-					{
-						int __itmp = i;
-						g_rehlds_sv.modelsMap.put(g_psv.model_precache[i], __itmp);
-					}
+						{
+							int __itmp = i;
+							g_rehlds_sv.modelsMap.put(g_psv.model_precache[i], __itmp);
+						}
 #endif
+					}
 				}
 			}
 #endif

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -202,6 +202,7 @@ cvar_t sv_rehlds_userinfo_transmitted_fields = { "sv_rehlds_userinfo_transmitted
 cvar_t sv_rehlds_attachedentities_playeranimationspeed_fix = {"sv_rehlds_attachedentities_playeranimationspeed_fix", "0", 0, 0.0f, nullptr};
 cvar_t sv_rehlds_local_gametime = {"sv_rehlds_local_gametime", "0", 0, 0.0f, nullptr};
 cvar_t sv_rehlds_send_mapcycle = { "sv_rehlds_send_mapcycle", "0", 0, 0.0f, nullptr };
+cvar_t sv_rehlds_maxclients_from_single_ip = { "sv_rehlds_maxclients_from_single_ip", "5", 0, 5.0f, nullptr };
 #endif
 
 delta_t *SV_LookupDelta(char *name)
@@ -1860,11 +1861,20 @@ int SV_CheckIPConnectionReuse(netadr_t *adr)
 		}
 	}
 
+#ifdef REHLDS_FIXES
+	if (count > (int)sv_rehlds_maxclients_from_single_ip.value)
+	{
+		Log_Printf("Too many connect packets from %s (%i>%i)\n", NET_AdrToString(*adr), count, (int)sv_rehlds_maxclients_from_single_ip.value);
+		SV_RejectConnection(adr, "Too many connect packets from your ip address\n");
+		return 0;
+	}
+#else
 	if (count > 5)
 	{
 		Log_Printf("Too many connect packets from %s\n", NET_AdrToString(*adr));
 		return 0;
 	}
+#endif
 
 	return 1;
 }
@@ -7798,6 +7808,7 @@ void SV_Init(void)
 	Cvar_RegisterVariable(&sv_rehlds_attachedentities_playeranimationspeed_fix);
 	Cvar_RegisterVariable(&sv_rehlds_local_gametime);
 	Cvar_RegisterVariable(&sv_rehlds_send_mapcycle);
+	Cvar_RegisterVariable(&sv_rehlds_maxclients_from_single_ip);
 
 	Cvar_RegisterVariable(&sv_rollspeed);
 	Cvar_RegisterVariable(&sv_rollangle);

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -6043,7 +6043,6 @@ int SV_SpawnServer(qboolean bIsDemo, char *server, char *startspot)
 	g_psv.model_precache[0] = pr_strings;
 #ifndef REHLDS_FIXES
 	g_psv.generic_precache[0] = pr_strings;
-#endif // REHLDS_FIXES
 
 	for (i = 1; i < g_psv.worldmodel->numsubmodels; i++)
 	{
@@ -6058,6 +6057,7 @@ int SV_SpawnServer(qboolean bIsDemo, char *server, char *startspot)
 		}
 #endif
 	}
+#endif // REHLDS_FIXES
 
 	Q_memset(&g_psv.edicts->v, 0, sizeof(entvars_t));
 
@@ -7798,7 +7798,7 @@ void SV_Init(void)
 	Cvar_RegisterVariable(&sv_rehlds_attachedentities_playeranimationspeed_fix);
 	Cvar_RegisterVariable(&sv_rehlds_local_gametime);
 	Cvar_RegisterVariable(&sv_rehlds_send_mapcycle);
-	
+
 	Cvar_RegisterVariable(&sv_rollspeed);
 	Cvar_RegisterVariable(&sv_rollangle);
 #endif

--- a/rehlds/msvc/ReHLDS.vcxproj
+++ b/rehlds/msvc/ReHLDS.vcxproj
@@ -766,7 +766,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>REHLDS_API;REHLDS_FLIGHT_REC;REHLDS_FIXES;REHLDS_SSE;REHLDS_OPT_PEDANTIC;REHLDS_SELF;REHLDS_CHECKS;HAVE_OPT_STRTOOLS;USE_BREAKPAD_HANDLER;DEDICATED;SWDS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>REHLDS_API;REHLDS_FIXES;REHLDS_SSE;REHLDS_OPT_PEDANTIC;REHLDS_SELF;REHLDS_CHECKS;HAVE_OPT_STRTOOLS;USE_BREAKPAD_HANDLER;DEDICATED;SWDS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalOptions>/arch:IA32 %(AdditionalOptions)</AdditionalOptions>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/rehlds/public/strtools.h
+++ b/rehlds/public/strtools.h
@@ -80,6 +80,7 @@ inline char *_strlwr(char *start)
 	#define Q_strstr A_strstr
 	#define Q_strchr strchr
 	#define Q_strrchr strrchr
+	#define Q_strtok strtok
 	#define Q_strlwr A_strtolower
 	#define Q_strupr A_strtoupper
 	#define Q_sprintf sprintf
@@ -120,6 +121,7 @@ inline char *_strlwr(char *start)
 	#define Q_strstr strstr
 	#define Q_strchr strchr
 	#define Q_strrchr strrchr
+	#define Q_strtok strtok
 	#define Q_strlwr _strlwr
 	#define Q_strupr _strupr
 	#define Q_sprintf sprintf
@@ -144,18 +146,17 @@ inline char *_strlwr(char *start)
 	#define Q_fmod fmod
 #endif // #if defined(ASMLIB_H) && defined(HAVE_OPT_STRTOOLS)
 
-// a safe variant of strcpy that truncates the result to fit in the destination buffer
-template <size_t size>
-char *Q_strlcpy(char (&dest)[size], const char *src) {
+// size - sizeof(buffer)
+inline char *Q_strlcpy(char *dest, const char *src, size_t size) {
 	Q_strncpy(dest, src, size - 1);
 	dest[size - 1] = '\0';
 	return dest;
 }
 
-inline char *Q_strnlcpy(char *dest, const char *src, size_t n) {
-	Q_strncpy(dest, src, n - 1);
-	dest[n - 1] = '\0';
-	return dest;
+// a safe variant of strcpy that truncates the result to fit in the destination buffer
+template <size_t size>
+char *Q_strlcpy(char (&dest)[size], const char *src) {
+	return Q_strlcpy(dest, src, size);
 }
 
 // safely concatenate two strings.

--- a/rehlds/unittests/info_tests.cpp
+++ b/rehlds/unittests/info_tests.cpp
@@ -3,8 +3,6 @@
 #include "cppunitlite/TestHarness.h"
 
 TEST(PrefixedKeysRemove, Info, 1000) {
-	EngineInitializer engInitGuard;
-
 	struct testdata_t {
 		const char* inData;
 		const char* outData;
@@ -12,9 +10,7 @@ TEST(PrefixedKeysRemove, Info, 1000) {
 
 	testdata_t testdata[] = {
 		{ "", "" },
-		{ "key\\value", "key\\value" },
 		{ "\\key\\value", "\\key\\value" },
-		{ "_key\\value", "" },
 		{ "\\_key\\value", "" },
 		{ "\\k\\v\\_u\\t\\y\\z", "\\k\\v\\y\\z" },
 		{ "\\_k\\v\\u\\t\\y\\z", "\\u\\t\\y\\z" },
@@ -34,8 +30,6 @@ TEST(PrefixedKeysRemove, Info, 1000) {
 }
 
 TEST(SetValueForStarKey, Info, 1000) {
-	EngineInitializer engInitGuard;
-
 	struct testdata_t {
 		const char* initialInfo;
 		const char* key;
@@ -45,20 +39,26 @@ TEST(SetValueForStarKey, Info, 1000) {
 
 	testdata_t testdata[] = {
 		// Behavior
-		{ "", "a", "b", "\\a\\b" },
-		{ "\\a\\b\\c\\d", "a", "b", "\\c\\d\\a\\b" },
-		{ "a\\b\\c\\d", "a", "b", "\\c\\d\\a\\b" },
+		{ "\\a\\b", "c", "d", "\\a\\b\\c\\d" },
+		{ "\\a\\b\\c\\d", "b", "f", "\\a\\b\\c\\d\\b\\f" },
+		{ "\\a\\b\\c\\d", "c", "", "\\a\\b" },
+		{ "\\a\\b\\c\\d\\e\\f", "c", "", "\\a\\b\\e\\f" },
+		{ "\\a\\b\\c\\d\\e\\f", "z", "", "\\a\\b\\c\\d\\e\\f" },
+		{ "\\a\\b\\c\\d", "a", "e", "\\c\\d\\a\\e" },
 		{ "\\a\\b\\c\\d", "e", "f", "\\a\\b\\c\\d\\e\\f" },
-		{ "a\\b\\c\\d", "e", "f", "a\\b\\c\\d\\e\\f" },
 		{ "\\a\\b\\c\\d", "b", "c", "\\a\\b\\c\\d\\b\\c" },
-		{ "\\a\\b\\c\\d\\e\\f", "c", "q", "\\a\\b\\e\\f\\c\\q" },
-		
+		{ "\\a\\b\\c\\d", "team", "aBcD", "\\a\\b\\c\\d\\team\\abcd" },
 
-		{ "\\a\\b\\c", "e", "f", "\\a\\b\\c\\e\\f" },
-		{ "\\a\\b\\c\\", "e", "f", "\\a\\b\\c\\\\e\\f" },
-		{ "\\a\\b\\\\c", "e", "f", "\\a\\b\\\\c\\e\\f" },
+		// Invalid keys/values
+		{ "\\a\\b", "c", nullptr, "\\a\\b" },
+		{ "\\a\\b", nullptr, "c", "\\a\\b" },
+		{ "\\a\\b", "c", "d..", "\\a\\b" },
+		{ "\\a\\b", "..c", "d", "\\a\\b" },
+		{ "\\a\\b", "c\"", "d", "\\a\\b" },
+		{ "\\a\\b", "c", "d\"", "\\a\\b" },
+		{ "\\a\\b", "c\\", "d", "\\a\\b" },
+		{ "\\a\\b", "c", "d\\", "\\a\\b" },
 
-		
 		//limits
 		{ //do nothing since 'team' is not important key
 			"\\cl_updaterate\\100\\topcolor\\60\\name\\abcdefghijklmnop\\*sid\\12332432525345\\_vgui_menus\\1\\model\\urban\\somelargeuselesskey\\12312321321323123123123213123123123123123123123123123123123123123dasdsad\\_cl_autowepswitch\\1",
@@ -95,9 +95,44 @@ TEST(SetValueForStarKey, Info, 1000) {
 	}
 }
 
-TEST(RemoveKeyValue, Info, 1000) {
-	EngineInitializer engInitGuard;
+#ifdef REHLDS_FIXES
+TEST(SetValueForStarKeyResult, Info, 1000) {
+	struct testdata_t {
+		const char* initialInfo;
+		const char* key;
+		const char* value;
+		bool success;
+	};
 
+	testdata_t testdata[] = {
+		// Behavior
+		{ "\\a\\b", "c", "d", true },
+		{ "\\a\\b\\c\\d", "b", "f", true },
+		{ "\\a\\b\\c\\d", "b", "c", true },
+
+		// Invalid keys/values
+		{ "\\a\\b", "c", nullptr, false },
+		{ "\\a\\b", nullptr, "c", false },
+		{ "\\a\\b", "c", "d..", false },
+		{ "\\a\\b", "..c", "d", false },
+		{ "\\a\\b", "c\"", "d", false },
+		{ "\\a\\b", "c", "d\"", false },
+		{ "\\a\\b", "c\\", "d", false },
+		{ "\\a\\b", "c", "d\\", false },
+	};
+
+	for (int i = 0; i < ARRAYSIZE(testdata); i++) {
+		testdata_t* d = &testdata[i];
+		char localInfo[256];
+		strcpy(localInfo, d->initialInfo);
+		localInfo[255] = 0;
+		bool result = Info_SetValueForStarKey(localInfo, d->key, d->value, 256);
+		CHECK("Invalid info string", d->success == result);
+	}
+}
+#endif
+
+TEST(RemoveKeyValue, Info, 1000) {
 	struct testdata_t {
 		const char* initialInfo;
 		const char* key;
@@ -107,18 +142,14 @@ TEST(RemoveKeyValue, Info, 1000) {
 	testdata_t testdata[] = {
 		{ "", "a", "" },
 		{ "\\a\\b", "a", "" },
-		{ "\\a\\", "a", "" },
-		{ "\\a\\\\", "a", "\\" },
-		{ "\\a", "a", "" },
-		{ "a", "a", "" },
-		{ "a\\", "a", "" },
-		{ "a\\b", "a", "" },
-		{ "a\\b\\", "a", "\\" },
 		{ "\\a\\b\\c\\d\\e\\f", "d", "\\a\\b\\c\\d\\e\\f" },
 		{ "\\a\\b\\c\\d\\e\\f", "c", "\\a\\b\\e\\f" },
-		{ "a\\b\\c\\d\\e\\f", "d", "a\\b\\c\\d\\e\\f" },
-		{ "a\\b\\c\\d\\e\\f", "c", "a\\b\\e\\f" },
-		{ "a\\b\\c\\d\\e\\f", "a", "\\c\\d\\e\\f" },
+#ifdef REHLDS_FIXES
+		{ "\\abc\\def\\x\\y\\ab\\cd", "ab", "\\abc\\def\\x\\y" },
+#else
+		{ "\\abc\\def\\x\\y\\ab\\cd", "ab", "\\x\\y" },
+#endif
+		{ "\\ab\\cd", "abc", "\\ab\\cd" }
 	};
 
 	for (int i = 0; i < ARRAYSIZE(testdata); i++) {
@@ -131,8 +162,6 @@ TEST(RemoveKeyValue, Info, 1000) {
 }
 
 TEST(GetKeyValue, Info, 1000) {
-	EngineInitializer engInitGuard;
-
 	struct testdata_t {
 		const char* info;
 		const char* key;
@@ -145,16 +174,8 @@ TEST(GetKeyValue, Info, 1000) {
 		{ "\\a\\", "a", "" },
 		{ "\\a\\\\", "a", "" },
 		{ "\\a", "a", "" },
-		{ "a", "a", "" },
-		{ "a\\", "a", "" },
-		{ "a\\b", "a", "b" },
-		{ "a\\b\\", "a", "b" },
 		{ "\\a\\b\\c\\d\\e\\f", "d", "" },
 		{ "\\a\\b\\c\\d\\e\\f", "c", "d" },
-		{ "a\\b\\c\\d\\e\\f", "d", "" },
-		{ "a\\b\\c\\d\\e\\f", "c", "d" },
-
-		{ "a\\b\\c\\d\\e\\f", "e", "f" },
 		{ "\\a\\b\\c\\d\\e\\f", "e", "f" },
 
 	};
@@ -164,5 +185,124 @@ TEST(GetKeyValue, Info, 1000) {
 
 		const char* res = Info_ValueForKey(d->info, d->key);
 		ZSTR_EQUAL("Invalid info value", d->result, res);
+	}
+}
+
+TEST(FindLargestKey, Info, 1000) {
+	struct testdata_t {
+		const char* info;
+		const char* result;
+	};
+
+	testdata_t testdata[] = {
+		{ "", "" },
+		{ "\\name\\a\\model\\b", "" },
+		{ "\\name\\a\\model\\b\\c\\d", "c" },
+		{ "\\name\\a\\1234567890abcdef\\b\\model\\c\\1234567890abcdefghi\\d\\rate\\1000", "1234567890abcdefghi" },
+		{ "\\name\\a\\1234567890abcdefghi\\b\\model\\c\\1234567890abcdef\\d\\rate\\1000", "1234567890abcdefghi" }
+	};
+
+	for (int i = 0; i < ARRAYSIZE(testdata); i++) {
+		testdata_t* d = &testdata[i];
+
+		const char* res = Info_FindLargestKey(d->info, MAX_INFO_STRING);
+		ZSTR_EQUAL("Invalid info value", d->result, res);
+	}
+}
+
+TEST(InfoIsValid, Info, 1000) {
+	struct testdata_t {
+		const char* info;
+		qboolean result;
+	};
+
+	testdata_t testdata[] = {
+		{ "", false }, // by original design
+#ifdef REHLDS_FIXES
+		{ "a\\b", false },
+#endif
+		{ "\\a\\b", true },
+		{ "\\a\\b\\c", false },
+		{ "\\a\\b\\c\\", false },
+		{ "\\a\\b\\c\\\\", false },
+#ifdef REHLDS_FIXES
+		{ "\\a\\b\\\\d", false },
+		{ "\\a\\b\\\\d\\", false },
+		{ "\\a\\b..c", false },
+		{ "\\a\\b\"c", false },
+		{ "\\a..b\\c", false },
+		{ "\\a\"b\\c", false },
+#endif
+		{ "\\a\\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", false },
+		{ "\\bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\\c", false },
+#ifdef REHLDS_FIXES
+		{ "\\a\\b\\c\\d\\a\\e", false },
+#endif
+		{ "\\aaab\\b\\c\\d\\aaa\\e", true },
+		{ "\\aaa\\b\\c\\d\\aaab\\e", true }
+	};
+
+	for (int i = 0; i < ARRAYSIZE(testdata); i++) {
+		testdata_t* d = &testdata[i];
+
+		char error[256];
+		snprintf(error, sizeof error, "Invalid result for string '%s'", d->info);
+
+		qboolean res = Info_IsValid(d->info);
+		CHECK(error, d->result == res);
+	}
+}
+
+#ifdef REHLDS_FIXES
+TEST(InfoCollectFields, Info, 1000)
+{
+	struct testdata_t {
+		const char* info;
+		const char* cvar;
+		const char* result;
+	};
+
+	testdata_t testdata[] = {
+		{ "\\cl_updaterate\\100\\topcolor\\60\\name\\abcdefghijklmnop\\*sid\\12332432525345\\_vgui_menus\\1\\model\\urban\\anykey\\1", "", "\\cl_updaterate\\100\\topcolor\\60\\name\\abcdefghijklmnop\\*sid\\12332432525345\\model\\urban\\anykey\\1" },
+		{ "\\cl_updaterate\\100\\topcolor\\60\\name\\abcdefghijklmnop\\*sid\\12332432525345\\_vgui_menus\\1\\model\\urban", "rate", "" },
+		{ "\\cl_updaterate\\100\\topcolor\\60\\name\\abcdefghijklmnop\\*sid\\12332432525345\\_vgui_menus\\1\\model\\urban", "topcolor\\*sid\\_vgui_menus", "\\topcolor\\60\\*sid\\12332432525345" },
+		{ "\\*hltv\\1dsgs", "*hltv", "\\*hltv\\1" },
+		{ "\\name\\player", "bottomcolor\\name", "\\name\\player" },
+	};
+
+	for (int i = 0; i < ARRAYSIZE(testdata); i++) {
+		testdata_t* d = &testdata[i];
+
+		char destinfo[MAX_INFO_STRING];
+		sv_rehlds_userinfo_transmitted_fields.string = (char *)d->cvar;
+		Info_SetFieldsToTransmit();
+		Info_CollectFields(destinfo, d->info, MAX_INFO_STRING);
+
+		ZSTR_EQUAL("Invalid info string", d->result, destinfo);
+	}
+}
+#endif
+
+TEST(Info_IsKeyImportant, Info, 1000)
+{
+	struct testdata_t {
+		const char* key;
+		bool result;
+	};
+
+	testdata_t testdata[] = {
+		{ "bottomcolor", true },
+		{ "bot", false },
+		{ "*any", true },
+		{ "_any", false },
+		{ "model2", false }
+	};
+
+	for (int i = 0; i < ARRAYSIZE(testdata); i++) {
+		testdata_t* d = &testdata[i];
+
+		bool result = Info_IsKeyImportant(d->key);
+
+		CHECK("wrong result", d->result == result);
 	}
 }


### PR DESCRIPTION
Should automatically merge changes back from upstream fork dreamstalker/rehlds into this fork for the split packet fix. I mean, just because those guys are retarded and think supressing a message == patching an exploit doesn't mean we have to go without bugfixes.